### PR TITLE
Fix/fisher empty

### DIFF
--- a/roles/anyenv/tasks/main.yml
+++ b/roles/anyenv/tasks/main.yml
@@ -1,27 +1,10 @@
 - block:
-  - name: Obtain path to fish
-    shell: which fish
-    register: fish_path
-    changed_when: false
-    check_mode: no
-
-  - name: Set ansible_shell_type to fish
-    set_fact:
-      ansible_shell_type: fish
-      ansible_shell_executable: '{{ fish_path.stdout }}'
 
   - name: Place anyenv repository
     git:
       repo: https://github.com/riywo/anyenv.git
-      dest: ~/.anyenv
+      dest: "{{ ansible_env.HOME }}/.anyenv"
       version: master
 
-  - name: Add init script of anyenv to config.fish
-    lineinfile:
-      dest: ~/.config/fish/config.fish
-      line: "{{ item }}"
-    with_items:
-      - set -x PATH $HOME/.anyenv/bin $PATH
-      - . (anyenv init - fish | psub)
   tags: anyenv_install
 

--- a/roles/fish/tasks/main.yml
+++ b/roles/fish/tasks/main.yml
@@ -35,15 +35,6 @@
       path: ~/.config/fish
       state: directory
 
-  - name: Put config files
-    file:
-      src: '{{ dotfiles_repo }}/{{ item }}'
-      dest: ~/{{ item }}
-      state: link
-      force: yes
-    with_items:
-      - '{{ fish_config_files }}'
-
   - name: Obtain path to fish
     shell: which fish
     register: fish_path
@@ -68,6 +59,15 @@
     until: download_result is succeeded
     retries: 3
     delay: 5
+
+  - name: Put config files
+    file:
+      src: '{{ dotfiles_repo }}/{{ item }}'
+      dest: ~/{{ item }}
+      state: link
+      force: yes
+    with_items:
+      - '{{ fish_config_files }}'
 
   - name: Install fish plugins
     shell: fisher


### PR DESCRIPTION
- dotfilesの行をAnsible Playbookで中途半端に管理するのをやめる
- fisher用のファイルを配置する順序を変更した
  - fishermanのインストール時に中身が消えてしまうため